### PR TITLE
Add Times class for comfort

### DIFF
--- a/spring-mvc-cache-control/src/main/java/net/rossillo/spring/web/mvc/Times.java
+++ b/spring-mvc-cache-control/src/main/java/net/rossillo/spring/web/mvc/Times.java
@@ -1,0 +1,9 @@
+package net.rossillo.spring.web.mvc;
+
+public class Times {
+    public static final int MINUTE = 60;
+    public static final int HOUR = 60 * MINUTE;
+    public static final int DAY = 24 * HOUR;
+    public static final int WEEK = 7 * DAY;
+    public static final int MONTH = 30 * DAY;
+}

--- a/spring-mvc-cache-control/src/test/java/net/rossillo/spring/web/mvc/CacheControlAnnotatedTestController.java
+++ b/spring-mvc-cache-control/src/test/java/net/rossillo/spring/web/mvc/CacheControlAnnotatedTestController.java
@@ -2,26 +2,28 @@ package net.rossillo.spring.web.mvc;
 
 import org.springframework.stereotype.Controller;
 
+import static net.rossillo.spring.web.mvc.Times.*;
+
 @CacheControl(policy = CachePolicy.PRIVATE)
 @Controller
 final class CacheControlAnnotatedTestController {
 	
-	@CacheControl(policy = CachePolicy.PUBLIC, maxAge = 60)
+	@CacheControl(policy = CachePolicy.PUBLIC, maxAge = DAY)
 	public String handlePubliclyCachedPageRequest() {
 		return null;
 	}
 	
-	@CacheControl(policy = { CachePolicy.MUST_REVALIDATE }, maxAge = 300)
+	@CacheControl(policy = {CachePolicy.MUST_REVALIDATE}, maxAge = 5 * HOUR)
 	public String handlePubliclyCachedPageAndRevalidatedRequest() {
 		return null;
 	}
 	
-	@CacheControl(policy = { CachePolicy.PUBLIC, CachePolicy.PROXY_REVALIDATE }, maxAge = 60)
+	@CacheControl(policy = {CachePolicy.PUBLIC, CachePolicy.PROXY_REVALIDATE}, maxAge = 2 * WEEK)
 	public String handlePubliclyCachedPageAndProxyRevalidatedRequest() {
 		return null;
 	}
 	
-	@CacheControl(policy = CachePolicy.PRIVATE, maxAge = 360)
+	@CacheControl(policy = CachePolicy.PRIVATE, maxAge = MONTH)
 	public String handlePrivatelyCachedPageRequest() {
 		return null;
 	}

--- a/spring-mvc-cache-control/src/test/java/net/rossillo/spring/web/mvc/CacheControlHandlerInterceptorTest.java
+++ b/spring-mvc-cache-control/src/test/java/net/rossillo/spring/web/mvc/CacheControlHandlerInterceptorTest.java
@@ -46,6 +46,7 @@ public final class CacheControlHandlerInterceptorTest {
 		
 		assertNotNull(response.getHeader("Cache-Control"));
 		assertTrue(response.getHeader("Cache-Control").contains("public"));
+		assertTrue(response.getHeader("Cache-Control").contains("max-age=86400"));
 		assertFalse(response.getHeader("Cache-Control").contains("private"));
 	}
 	
@@ -62,6 +63,7 @@ public final class CacheControlHandlerInterceptorTest {
 		
 		assertNotNull(response.getHeader("Cache-Control"));
 		assertTrue(response.getHeader("Cache-Control").contains("public"));
+		assertTrue(response.getHeader("Cache-Control").contains("max-age=1209600"));
 		assertTrue(response.getHeader("Cache-Control").contains("proxy-revalidate"));
 		assertFalse(response.getHeader("Cache-Control").contains("private"));
 	}
@@ -78,6 +80,7 @@ public final class CacheControlHandlerInterceptorTest {
 		System.err.println("CC: " + response.getHeader("Cache-Control"));
 		
 		assertNotNull(response.getHeader("Cache-Control"));
+		assertTrue(response.getHeader("Cache-Control").contains("max-age=18000"));
 		assertTrue(response.getHeader("Cache-Control").contains("must-revalidate"));
 		assertFalse(response.getHeader("Cache-Control").contains("private"));
 	}
@@ -95,6 +98,7 @@ public final class CacheControlHandlerInterceptorTest {
 		
 		assertNotNull(response.getHeader("Cache-Control"));
 		assertTrue(response.getHeader("Cache-Control").contains("private"));
+		assertTrue(response.getHeader("Cache-Control").contains("max-age=2592000"));
 		assertFalse(response.getHeader("Cache-Control").contains("public"));
 	}
 	


### PR DESCRIPTION
Every time I used cache control headers, I had to write my own `Times.java` so that I can set the `max-age` comfortably withour repeating myself. However, I think this should be part of the package :)